### PR TITLE
Update constraint name length to max 31 character

### DIFF
--- a/src/Firebird/Schema/Grammars/FirebirdGrammar.php
+++ b/src/Firebird/Schema/Grammars/FirebirdGrammar.php
@@ -143,7 +143,7 @@ class FirebirdGrammar extends Grammar {
 
     $onColumns = $this->columnize((array) $command->references);
 
-    $sql = "alter table {$table} add constraint ".strtoupper(substr($command->index, 0, 20))." ";
+    $sql = "alter table {$table} add constraint ".strtoupper(substr($command->index, 0, 31))." ";
 
     $sql .= "foreign key ({$columns}) references {$on} ({$onColumns})";
 


### PR DESCRIPTION
Metadata names are restricted to 31 characters.
reference: https://www.ibphoenix.com/resources/documents/general/doc_323
